### PR TITLE
🔧 Fix DevContainer project name conflict between terminal and VSCode

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -1,3 +1,5 @@
+name: ezqrin
+
 services:
   api:
     container_name: ezqrin-api


### PR DESCRIPTION
## Summary

Fixes a container name conflict that caused VSCode's "Reopen in Container" to fail when `make dev-up` was already running.

When running `make dev-up` from the terminal, Docker Compose derived the project name from the directory name (`devcontainer`), while VSCode's Dev Containers extension used its own project name. Since `container_name` values were hardcoded in `docker-compose.yaml`, both tried to claim containers with the same fixed names under different Compose projects, causing a conflict.

## Changes

- Add `name: ezqrin` to `.devcontainer/docker-compose.yaml` to enforce a consistent Compose project name regardless of how the file is invoked (terminal or VSCode)

## Testing

- [ ] `make dev-up` starts services successfully
- [ ] VSCode "Reopen in Container" works while services are running via `make dev-up`
- [ ] No container name conflicts observed

## Checklist

- [ ] All acceptance criteria met
- [ ] Documentation updated (if needed)
- [ ] Ready for review