### PR TITLE
🐛 Fix missing fields in check-in API responses and improve null handling

### DIFF
--- a/internal/interface/api/handler/checkin.go
+++ b/internal/interface/api/handler/checkin.go
@@ -262,7 +262,7 @@ func (h *CheckinHandler) convertCheckInsToItems(checkIns []*checkin.CheckInOutpu
 		Name string             `json:"name"`
 	} `json:"checked_in_by"`
 	CheckinMethod generated.CheckInMethod `json:"checkin_method"`
-	DeviceInfo    *map[string]interface{} `json:"device_info,omitempty"`
+	DeviceInfo    *map[string]any         `json:"device_info,omitempty"`
 	EventId       openapi_types.UUID      `json:"event_id"`
 	Id            openapi_types.UUID      `json:"id"`
 	Participant   struct {
@@ -279,7 +279,7 @@ func (h *CheckinHandler) convertCheckInsToItems(checkIns []*checkin.CheckInOutpu
 			Name string             `json:"name"`
 		} `json:"checked_in_by"`
 		CheckinMethod generated.CheckInMethod `json:"checkin_method"`
-		DeviceInfo    *map[string]interface{} `json:"device_info,omitempty"`
+		DeviceInfo    *map[string]any         `json:"device_info,omitempty"`
 		EventId       openapi_types.UUID      `json:"event_id"`
 		Id            openapi_types.UUID      `json:"id"`
 		Participant   struct {
@@ -296,6 +296,7 @@ func (h *CheckinHandler) convertCheckInsToItems(checkIns []*checkin.CheckInOutpu
 		items[i].ParticipantId = openapi_types.UUID(ci.ParticipantID)
 		items[i].Participant.Name = ci.ParticipantName
 		items[i].Participant.Email = openapi_types.Email(ci.ParticipantEmail)
+		items[i].Participant.EmployeeId = ci.ParticipantEmployeeID
 		items[i].CheckedInAt = ci.CheckedInAt
 		items[i].CheckinMethod = generated.CheckInMethod(ci.Method)
 
@@ -319,9 +320,17 @@ func (h *CheckinHandler) buildCheckInStatusResponse(
 	output *checkin.CheckInStatusOutput,
 ) generated.CheckInStatusResponse {
 	resp := generated.CheckInStatusResponse{
-		ParticipantId: openapi_types.UUID(output.ParticipantID),
-		CheckedIn:     output.IsCheckedIn,
-		Checkin:       nil,
+		ParticipantId:   openapi_types.UUID(output.ParticipantID),
+		ParticipantName: output.ParticipantName,
+		EventId:         openapi_types.UUID(output.EventID),
+		EventName:       output.EventName,
+		CheckedIn:       output.IsCheckedIn,
+		Checkin:         nil,
+	}
+
+	if output.ParticipantEmail != "" {
+		email := openapi_types.Email(output.ParticipantEmail)
+		resp.ParticipantEmail = &email
 	}
 
 	if output.CheckIn != nil {
@@ -332,7 +341,7 @@ func (h *CheckinHandler) buildCheckInStatusResponse(
 				Name string             `json:"name"`
 			} `json:"checked_in_by"`
 			CheckinMethod generated.CheckInMethod `json:"checkin_method"`
-			DeviceInfo    *map[string]interface{} `json:"device_info,omitempty"`
+			DeviceInfo    *map[string]any         `json:"device_info,omitempty"`
 			Id            openapi_types.UUID      `json:"id"`
 		}{
 			Id:            openapi_types.UUID(output.CheckIn.ID),

--- a/internal/usecase/checkin/get_status.go
+++ b/internal/usecase/checkin/get_status.go
@@ -40,9 +40,13 @@ func (u *checkinUsecase) GetStatus(
 		var appErr *apperrors.AppError
 		if errors.As(err, &appErr) && appErr.Code == apperrors.CodeNotFound {
 			return &CheckInStatusOutput{
-				ParticipantID: participantID,
-				IsCheckedIn:   false,
-				CheckIn:       nil,
+				ParticipantID:    participantID,
+				ParticipantName:  participant.Name,
+				ParticipantEmail: participant.Email,
+				EventID:          event.ID,
+				EventName:        event.Name,
+				IsCheckedIn:      false,
+				CheckIn:          nil,
 			}, nil
 		}
 		return nil, fmt.Errorf("failed to get check-in status: %w", err)
@@ -50,18 +54,13 @@ func (u *checkinUsecase) GetStatus(
 
 	// Build output with check-in details
 	output := &CheckInStatusOutput{
-		ParticipantID: participantID,
-		IsCheckedIn:   true,
-		CheckIn: &CheckInOutput{
-			ID:               checkin.ID,
-			EventID:          checkin.EventID,
-			ParticipantID:    participant.ID,
-			ParticipantName:  participant.Name,
-			ParticipantEmail: participant.Email,
-			CheckedInAt:      checkin.CheckedInAt,
-			CheckedInBy:      checkin.CheckedInBy,
-			Method:           checkin.Method,
-		},
+		ParticipantID:    participantID,
+		ParticipantName:  participant.Name,
+		ParticipantEmail: participant.Email,
+		EventID:          event.ID,
+		EventName:        event.Name,
+		IsCheckedIn:      true,
+		CheckIn:          u.buildCheckInOutput(checkin, participant),
 	}
 
 	return output, nil

--- a/internal/usecase/checkin/list.go
+++ b/internal/usecase/checkin/list.go
@@ -45,17 +45,7 @@ func (u *checkinUsecase) List(
 			continue
 		}
 
-		output := &CheckInOutput{
-			ID:               checkin.ID,
-			EventID:          checkin.EventID,
-			ParticipantID:    participant.ID,
-			ParticipantName:  participant.Name,
-			ParticipantEmail: participant.Email,
-			CheckedInAt:      checkin.CheckedInAt,
-			CheckedInBy:      checkin.CheckedInBy,
-			Method:           checkin.Method,
-		}
-		outputs = append(outputs, output)
+		outputs = append(outputs, u.buildCheckInOutput(checkin, participant))
 	}
 
 	return &ListCheckInsOutput{

--- a/internal/usecase/checkin/types.go
+++ b/internal/usecase/checkin/types.go
@@ -14,26 +14,31 @@ type CheckInInput struct {
 	QRCode        *string
 	ParticipantID *uuid.UUID
 	CheckedInBy   uuid.UUID
-	DeviceInfo    map[string]interface{}
+	DeviceInfo    map[string]any
 }
 
 // CheckInOutput represents output after checking in
 type CheckInOutput struct {
-	ID               uuid.UUID
-	EventID          uuid.UUID
-	ParticipantID    uuid.UUID
-	ParticipantName  string
-	ParticipantEmail string
-	CheckedInAt      time.Time
-	CheckedInBy      *uuid.UUID
-	Method           entity.CheckinMethod
+	ID                    uuid.UUID
+	EventID               uuid.UUID
+	ParticipantID         uuid.UUID
+	ParticipantName       string
+	ParticipantEmail      string
+	ParticipantEmployeeID *string
+	CheckedInAt           time.Time
+	CheckedInBy           *uuid.UUID
+	Method                entity.CheckinMethod
 }
 
 // CheckInStatusOutput represents check-in status for a participant
 type CheckInStatusOutput struct {
-	ParticipantID uuid.UUID
-	IsCheckedIn   bool
-	CheckIn       *CheckInOutput
+	ParticipantID    uuid.UUID
+	ParticipantName  string
+	ParticipantEmail string
+	EventID          uuid.UUID
+	EventName        string
+	IsCheckedIn      bool
+	CheckIn          *CheckInOutput
 }
 
 // ListCheckInsInput represents input for listing check-ins


### PR DESCRIPTION
## Summary

Fix multiple bugs in the check-in API where required response fields were missing, `CheckedInBy` was always set to a non-nil pointer (causing potential FK violations in self-service scenarios), and `convertDeviceInfo` silently swallowed marshaling errors.

## Changes

- Add `EventId`, `EventName`, `ParticipantName`, `ParticipantEmail` to `GetCheckInStatus` response (were always zero values)
- Add `ParticipantEmployeeID` to `CheckIn` and `ListCheckIns` responses (was never populated)
- Fix `CheckedInBy` to be `nil` when `userID` is `uuid.Nil` (self-service kiosk support via QR code)
- Propagate `convertDeviceInfo` marshal error instead of silently returning `nil`
- Refactor `CheckInOutput` construction to reuse `buildCheckInOutput` helper (DRY)
- Replace `interface{}` with `any` throughout the checkin package

## Testing

- [x] Unit tests passing (`make test` — all packages OK)
- [x] Lint passing (`make lint` — 0 issues)
- [x] Code reviewed against CLAUDE.md standards

## Checklist

- [x] All acceptance criteria met
- [ ] Documentation updated (if needed)
- [x] Ready for review