### PR TITLE
🚀 Add production Dockerfile with Docker/Podman support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,30 @@
+# Version control
+.git
+.github
+
+# Claude configuration
+.claude
+
+# Documentation
+docs
+
+# Markdown files
+*.md
+
+# Environment files (secrets)
+.env
+.env.*
+!.env.example
+
+# Development containers
+.devcontainer
+
+# Temporary files
+tmp/
+
+# Test output
+*.test
+*.out
+
+# Serena
+.serena

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# Build stage
+FROM golang:1.25.5-alpine AS builder
+
+WORKDIR /build
+
+# Download dependencies first (layer cache optimization)
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source and build binaries
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+    -ldflags="-w -s" -o ezqrin-server ./cmd/api/main.go && \
+    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo \
+    -ldflags="-w -s" -o ezqrin-migrate ./cmd/migrate/main.go
+
+# Production stage
+FROM alpine:3.21 AS production
+
+# curl for health checks, ca-certificates for HTTPS
+RUN apk add --no-cache ca-certificates curl
+
+WORKDIR /app
+
+# Copy binaries
+COPY --from=builder /build/ezqrin-server .
+COPY --from=builder /build/ezqrin-migrate .
+
+# Copy runtime config (YAML only, no .go or _test.go files)
+COPY config/default.yaml ./config/
+COPY config/production.yaml ./config/
+
+# Copy migration SQL files
+COPY internal/infrastructure/database/migrations/ ./internal/infrastructure/database/migrations/
+
+EXPOSE 8080
+
+# Run as non-root
+USER nobody
+
+CMD ["./ezqrin-server"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,7 +44,7 @@ services:
     tmpfs:
       - /tmp
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-f", "--silent", "http://localhost:8080/api/v1/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## Summary

Add a production-ready multi-stage Dockerfile to the repository root, enabling container-based deployment compatible with both Docker and Podman. Also fixes the healthcheck URL and updates DEPLOYMENT.md to document Podman alternatives alongside Docker commands.

## Changes

- **`Dockerfile`** (new): Multi-stage build using `golang:1.25.5-alpine` as builder and `alpine:3.21` as runtime. Runs as non-root (`nobody`), includes both server binaries, YAML config files, and migration SQL files
- **`.dockerignore`** (new): Excludes `.git`, `docs`, `.claude`, `.env*`, `.devcontainer`, `.serena` from build context to improve security and build speed
- **`docker-compose.prod.yml`**: Updated API healthcheck from `wget` to `curl -f` and corrected URL from `/health` to `/api/v1/health` (matches actual router path)
- **`DEPLOYMENT.md`**: Removed inline Dockerfile example (now references actual file), added Podman install instructions and `podman`/`podman-compose` alternatives for every Docker command

## Testing

- [ ] `docker build -t ezqrin-server:latest .` (or `podman build`) succeeds
- [ ] `docker run --rm ezqrin-server:latest ls -la` shows both `ezqrin-server` and `ezqrin-migrate`
- [ ] `docker compose -f docker-compose.prod.yml config` passes without errors
- [ ] `curl http://localhost:8080/api/v1/health` returns `200 OK` in a running deployment

## Checklist

- [ ] All acceptance criteria met
- [ ] Documentation updated (DEPLOYMENT.md)
- [ ] Ready for review