### PR TITLE
🔧 Fix devcontainer volumes to use fixed names for data persistence

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -77,7 +77,9 @@ services:
 
 volumes:
   postgres-data:
+    name: ezqrin_postgres-data
   redis-data:
+    name: ezqrin_redis-data
 
 networks:
   devcontainer-network:


### PR DESCRIPTION
## Summary
Dev Container volumes were recreated with new names on each rebuild because Docker Compose prefixes volume names with the project name. By specifying explicit `name` values, volumes always reference the same fixed names (`ezqrin_postgres-data`, `ezqrin_redis-data`) regardless of the Compose project name.

## Changes
- Set fixed `name: ezqrin_postgres-data` for PostgreSQL volume
- Set fixed `name: ezqrin_redis-data` for Redis volume

## Testing
- [ ] Unit tests added/passing
- [ ] Code reviewed against CLAUDE.md standards

## Checklist
- [ ] All acceptance criteria met
- [ ] Documentation updated (if needed)
- [ ] Ready for review