### PR TITLE
🐛 Fix PostgreSQL data persistence by setting PGDATA explicitly

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -41,11 +41,12 @@ services:
     image: postgres:18-alpine
     restart: unless-stopped
     volumes:
-      - postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql
     environment:
       POSTGRES_USER: ezqrin
       POSTGRES_PASSWORD: ezqrin_dev
       POSTGRES_DB: ezqrin_db
+      PGDATA: /var/lib/postgresql/data/pgdata
     ports:
       - "5432:5432"
     healthcheck:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -64,6 +64,7 @@ services:
       POSTGRES_USER: ${DB_USER}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_DB: ${DB_NAME}
+      PGDATA: /var/lib/postgresql/data/pgdata
     networks:
       - ezqrin-internal
     security_opt:


### PR DESCRIPTION
## Summary
PostgreSQL 18-alpine changed the default PGDATA path from `/var/lib/postgresql/data` to `/var/lib/postgresql/18/docker`, causing data to be written outside the volume mount and lost on container restart. This PR explicitly sets the `PGDATA` environment variable and adjusts the volume mount to ensure data persists correctly.

## Changes
- Set `PGDATA=/var/lib/postgresql/data/pgdata` in devcontainer docker-compose
- Adjust devcontainer volume mount to `/var/lib/postgresql` (parent directory)
- Add `PGDATA` environment variable to production docker-compose

## Testing
- [ ] Verified PostgreSQL data persists across container restarts in devcontainer
- [ ] Verified production docker-compose configuration is valid

## Checklist
- [x] Fix applied to both devcontainer and production environments
- [x] Ready for review