### PR TITLE
📝 Add CHANGELOG.md entry for v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-05-05
+
+### Added
+- OpenTelemetry observability across HTTP, PostgreSQL, and Redis layers — traces, metrics, and structured logs exported via OTLP gRPC, with `OTEL_*` environment variables (and `OTEL_ENABLED=false` to opt out) (#76)
+- Local telemetry stack (`docker-compose.telemetry.yaml`) bundling OTel Collector, Jaeger, Prometheus, Loki, and Grafana, runnable via `make telemetry-up` / `make telemetry-down` (#76)
+
+### Changed
+- Upgraded Go runtime from 1.25.5 to 1.26.1 (#67)
+- Eliminated cross-layer code duplication and standardized error handling (#73)
+- Removed package-level globals in favor of dependency injection, generated usecase mocks, and fixed transaction context propagation in repositories (#74)
+
 ## [0.1.0] - 2026-03-14
 
 Initial beta release of ezQRin Server — a Go-based backend API for QR code-based event check-in management.
@@ -51,4 +62,5 @@ Initial beta release of ezQRin Server — a Go-based backend API for QR code-bas
 - GitHub Actions CI pipeline (lint + vet + test in parallel)
 - Ginkgo/Gomega BDD-style integration and E2E test suite
 
+[0.2.0]: https://github.com/fumkob/ezqrin-server/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/fumkob/ezqrin-server/releases/tag/v0.1.0


### PR DESCRIPTION
## Summary

Document the changes accumulated on `main` since `v0.1.0` so that the upcoming `v0.2.0` tag has a corresponding CHANGELOG section. Once merged, the `v0.2.0` tag will be cut from `main` and trigger the GitHub Actions release workflow.

## Included in v0.2.0

### Added
- OpenTelemetry observability across HTTP / PostgreSQL / Redis with traces, metrics, and structured logs over OTLP gRPC; opt-out via `OTEL_ENABLED=false` (#76)
- Local telemetry stack (`docker-compose.telemetry.yaml`) bundling OTel Collector + Jaeger + Prometheus + Loki + Grafana, runnable via `make telemetry-up` / `make telemetry-down` (#76)

### Changed
- Upgrade Go runtime from 1.25.5 to 1.26.1 (#67)
- Eliminate cross-layer code duplication and standardize error handling (#73)
- Remove package-level globals in favor of DI, generated usecase mocks, and fix transaction context propagation in repositories (#74)

Documentation-only PRs (#72, #75), test additions (#68–#71), and the release workflow (#65) are intentionally omitted from the user-facing CHANGELOG.

## Test plan

- [x] `CHANGELOG.md` follows the same Keep a Changelog format as `[0.1.0]`
- [x] Compare link `[0.2.0]` points to `v0.1.0...v0.2.0`
- [ ] After merge, tag `v0.2.0` from `main` and confirm the release workflow publishes the GitHub Release