### PR TITLE
🐛 Pass CHANGELOG body via env var to preserve backticks in release notes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,6 +41,7 @@ jobs:
         run: |
           gh release create "$GITHUB_REF_NAME" \
             --title "$GITHUB_REF_NAME" \
-            --notes "${{ steps.changelog.outputs.body }}"
+            --notes "$RELEASE_BODY"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BODY: ${{ steps.changelog.outputs.body }}


### PR DESCRIPTION
## Summary
- The Release workflow inlined `${{ steps.changelog.outputs.body }}` directly into the `gh release create --notes "..."` argument. GitHub Actions template expansion runs *before* shell parsing, so any backtick-quoted text in the CHANGELOG (e.g. `` `kin-openapi` ``, `` `make telemetry-up` ``) ended up inside a double-quoted bash string and was evaluated as command substitution — silently producing empty strings, and in some cases actually executing the command on the runner and leaking its stdout into the release notes.
- Fix: pass the body through an `env:` variable (`RELEASE_BODY`) and reference it as `"$RELEASE_BODY"` in the shell command. Variable expansion treats the value as literal text and does not re-evaluate backticks. This is also the [GitHub-recommended pattern](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) to prevent script injection.
- Notes for v0.2.0 and v0.2.1 have already been re-published manually with the corrected content; this fix prevents the issue from recurring on future releases.

## Test plan
- [ ] Next time a tag is pushed, confirm the resulting GitHub Release notes preserve backticks and that no commands from the CHANGELOG are executed on the runner.