### PR TITLE
🐛 Apply sort and order query params to event list (#49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-05-06
+
+### Fixed
+- Apply `sort` and `order` query parameters on `GET /events` to the database query — previously they were silently ignored and results were always sorted by `created_at DESC`. Sortable columns are restricted via a whitelist (`created_at`, `updated_at`, `name`, `start_date`, `end_date`, `status`) to guard against SQL injection. (#49)
+- Preserve backticks in GitHub Release notes generated from CHANGELOG entries by passing the body via an environment variable in the release workflow. (#79)
+
 ## [0.2.1] - 2026-05-06
 
 ### Changed
@@ -72,6 +78,7 @@ Initial beta release of ezQRin Server — a Go-based backend API for QR code-bas
 - GitHub Actions CI pipeline (lint + vet + test in parallel)
 - Ginkgo/Gomega BDD-style integration and E2E test suite
 
+[0.2.2]: https://github.com/fumkob/ezqrin-server/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/fumkob/ezqrin-server/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/fumkob/ezqrin-server/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/fumkob/ezqrin-server/releases/tag/v0.1.0

--- a/internal/domain/repository/event_repository.go
+++ b/internal/domain/repository/event_repository.go
@@ -17,6 +17,8 @@ type EventListFilter struct {
 	Search      string
 	StartDate   *time.Time
 	EndDate     *time.Time
+	Sort        string // sort column name (empty = default "created_at")
+	Order       string // "asc" | "desc" (empty = default "desc")
 }
 
 // EventStats represents basic statistics for an event.

--- a/internal/infrastructure/database/event_repository.go
+++ b/internal/infrastructure/database/event_repository.go
@@ -16,6 +16,16 @@ import (
 	"go.uber.org/zap"
 )
 
+// allowedEventSortColumns maps accepted sort parameter values to their SQL column expressions.
+var allowedEventSortColumns = map[string]string{
+	"created_at": "e.created_at",
+	"updated_at": "e.updated_at",
+	"name":       "e.name",
+	"start_date": "e.start_date",
+	"end_date":   "e.end_date",
+	"status":     "e.status",
+}
+
 // EventRepository implements repository.EventRepository using PostgreSQL
 type EventRepository struct {
 	pool   *pgxpool.Pool
@@ -135,9 +145,9 @@ func (r *EventRepository) List(
 			(SELECT COUNT(*) FROM checkins WHERE event_id = e.id) AS checked_in_count
 		FROM events e
 		WHERE %s
-		ORDER BY e.created_at DESC
+		ORDER BY %s
 		LIMIT $%d OFFSET $%d
-	`, whereSQL, argIdx, argIdx+1)
+	`, whereSQL, buildOrderByClause(filter), argIdx, argIdx+1)
 
 	args = append(args, limit, offset)
 	rows, err := q.Query(ctx, query, args...)
@@ -314,6 +324,23 @@ func (r *EventRepository) scanEventRows(rows pgx.Rows, capacity int) ([]*entity.
 		return nil, apperrors.Wrapf(err, "error iterating event rows")
 	}
 	return events, nil
+}
+
+// buildOrderByClause constructs a safe ORDER BY clause from filter.Sort and filter.Order.
+// Unknown sort values fall back to "e.created_at"; unknown order values fall back to "DESC".
+// A secondary sort on "e.id ASC" is appended for stable pagination.
+func buildOrderByClause(filter repository.EventListFilter) string {
+	col, ok := allowedEventSortColumns[strings.ToLower(filter.Sort)]
+	if !ok {
+		col = "e.created_at"
+	}
+
+	dir := "DESC"
+	if strings.EqualFold(filter.Order, "asc") {
+		dir = "ASC"
+	}
+
+	return fmt.Sprintf("%s %s, e.id ASC", col, dir)
 }
 
 func (r *EventRepository) buildListWhereClause(filter repository.EventListFilter) (string, []interface{}, int) {

--- a/internal/infrastructure/database/event_repository_test.go
+++ b/internal/infrastructure/database/event_repository_test.go
@@ -190,6 +190,80 @@ var _ = Describe("EventRepository", func() {
 			Expect(total2).To(Equal(int64(5)))
 			Expect(events2).To(HaveLen(2))
 		})
+
+		Context("when Sort and Order params are specified", func() {
+			It("should default to created_at DESC when Sort and Order are empty", func() {
+				filter := repository.EventListFilter{OrganizerID: &testUserID}
+				events, _, err := repo.List(ctx, filter, 0, 10)
+				Expect(err).To(BeNil())
+				Expect(events).To(HaveLen(5))
+				// Event 5 has the largest (most recent) CreatedAt, so it should come first
+				Expect(events[0].Name).To(Equal("Event 5"))
+				Expect(events[4].Name).To(Equal("Event 1"))
+			})
+
+			It("should return events in name ASC order when sort=name and order=asc", func() {
+				filter := repository.EventListFilter{
+					OrganizerID: &testUserID,
+					Sort:        "name",
+					Order:       "asc",
+				}
+				events, _, err := repo.List(ctx, filter, 0, 10)
+				Expect(err).To(BeNil())
+				Expect(events).To(HaveLen(5))
+				names := make([]string, len(events))
+				for i, e := range events {
+					names[i] = e.Name
+				}
+				Expect(names).To(Equal([]string{"Event 1", "Event 2", "Event 3", "Event 4", "Event 5"}))
+			})
+
+			It("should return events in name DESC order when sort=name and order=desc", func() {
+				filter := repository.EventListFilter{
+					OrganizerID: &testUserID,
+					Sort:        "name",
+					Order:       "desc",
+				}
+				events, _, err := repo.List(ctx, filter, 0, 10)
+				Expect(err).To(BeNil())
+				Expect(events).To(HaveLen(5))
+				names := make([]string, len(events))
+				for i, e := range events {
+					names[i] = e.Name
+				}
+				Expect(names).To(Equal([]string{"Event 5", "Event 4", "Event 3", "Event 2", "Event 1"}))
+			})
+
+			It("should return events in start_date ASC order when sort=start_date and order=asc", func() {
+				filter := repository.EventListFilter{
+					OrganizerID: &testUserID,
+					Sort:        "start_date",
+					Order:       "asc",
+				}
+				events, _, err := repo.List(ctx, filter, 0, 10)
+				Expect(err).To(BeNil())
+				Expect(events).To(HaveLen(5))
+				// Verify the result is ordered ascending by start_date (stable via secondary sort id ASC)
+				for i := 1; i < len(events); i++ {
+					Expect(events[i].StartDate).To(BeTemporally(">=", events[i-1].StartDate))
+				}
+			})
+
+			It("should fall back to created_at DESC and not error when Sort is an invalid/injection value", func() {
+				filter := repository.EventListFilter{
+					OrganizerID: &testUserID,
+					Sort:        "; DROP TABLE events; --",
+				}
+				events, total, err := repo.List(ctx, filter, 0, 10)
+				// Must not return an error and all rows must survive (no injection damage)
+				Expect(err).To(BeNil())
+				Expect(total).To(Equal(int64(5)))
+				Expect(events).To(HaveLen(5))
+				// Invalid Sort falls back to e.created_at; empty Order falls back to DESC,
+				// so Event 5 (most recent) comes first.
+				Expect(events[0].Name).To(Equal("Event 5"))
+			})
+		})
 	})
 
 	When("updating an event", func() {

--- a/internal/interface/api/handler/event_test.go
+++ b/internal/interface/api/handler/event_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -61,6 +62,32 @@ func newEventHandlerRouter(uc event.Usecase, userID uuid.UUID, role string, log 
 	r.PUT("/events/:id", func(c *gin.Context) {
 		id, _ := uuid.Parse(c.Param("id"))
 		h.PutEventsId(c, id)
+	})
+
+	return r
+}
+
+// newEventHandlerRouterWithParams creates a Gin router that passes explicit GetEventsParams to GetEvents.
+func newEventHandlerRouterWithParams(
+	uc event.Usecase,
+	userID uuid.UUID,
+	role string,
+	log *logger.Logger,
+	params generated.GetEventsParams,
+) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	r := gin.New()
+
+	r.Use(func(c *gin.Context) {
+		c.Set(middleware.ContextKeyUserID, userID)
+		c.Set(middleware.ContextKeyUserRole, role)
+		c.Next()
+	})
+
+	h := handler.NewEventHandler(uc, log)
+
+	r.GET("/events", func(c *gin.Context) {
+		h.GetEvents(c, params)
 	})
 
 	return r
@@ -183,6 +210,36 @@ var _ = Describe("EventHandler", func() {
 					second := events[1].(map[string]interface{})
 					Expect(second["participant_count"]).To(BeEquivalentTo(20))
 					Expect(second["checked_in_count"]).To(BeEquivalentTo(18))
+				})
+			})
+
+			Context("with sort=name and order=asc query params", func() {
+				It("should propagate Sort and Order to the usecase ListEventsInput", func() {
+					sortName := generated.SortParam("name")
+					orderAsc := generated.GetEventsParamsOrderAsc
+					params := generated.GetEventsParams{
+						Sort:  &sortName,
+						Order: &orderAsc,
+					}
+
+					var capturedInput event.ListEventsInput
+					mockUC := eventMocks.NewMockUsecase(ctrl)
+					mockUC.EXPECT().
+						List(gomock.Any(), gomock.Any()).
+						DoAndReturn(func(_ context.Context, input event.ListEventsInput) (event.ListEventsOutput, error) {
+							capturedInput = input
+							return event.ListEventsOutput{Events: []*entity.Event{}, TotalCount: 0}, nil
+						})
+
+					r := newEventHandlerRouterWithParams(mockUC, organizerID, "organizer", log, params)
+
+					req := httptest.NewRequest(http.MethodGet, "/events", nil)
+					w := httptest.NewRecorder()
+					r.ServeHTTP(w, req)
+
+					Expect(w.Code).To(Equal(http.StatusOK))
+					Expect(capturedInput.Sort).To(Equal("name"))
+					Expect(capturedInput.Order).To(Equal("asc"))
 				})
 			})
 		})

--- a/internal/usecase/event/usecase.go
+++ b/internal/usecase/event/usecase.go
@@ -64,6 +64,8 @@ func (u *eventUsecase) List(ctx context.Context, input ListEventsInput) (ListEve
 		OrganizerID: input.OrganizerID,
 		Status:      input.Status,
 		Search:      input.Search,
+		Sort:        input.Sort,
+		Order:       input.Order,
 	}
 
 	offset := (input.Page - 1) * input.PerPage

--- a/internal/usecase/event/usecase_test.go
+++ b/internal/usecase/event/usecase_test.go
@@ -869,6 +869,117 @@ var _ = Describe("EventUsecase", func() {
 				Expect(errors.Is(err, context.Canceled)).To(BeTrue())
 			})
 		})
+
+		When("sorting and ordering", func() {
+			Context("with sort=name and order=asc", func() {
+				It("should pass Sort and Order to the repository filter", func() {
+					var capturedFilter repository.EventListFilter
+					mockRepo.listFunc = func(
+						ctx context.Context,
+						filter repository.EventListFilter,
+						offset, limit int,
+					) ([]*entity.Event, int64, error) {
+						capturedFilter = filter
+						return []*entity.Event{}, 0, nil
+					}
+
+					input := event.ListEventsInput{
+						Page:    1,
+						PerPage: 20,
+						Sort:    "name",
+						Order:   "asc",
+					}
+
+					_, err := usecase.List(ctx, input)
+
+					Expect(err).To(BeNil())
+					Expect(capturedFilter.Sort).To(Equal("name"))
+					Expect(capturedFilter.Order).To(Equal("asc"))
+				})
+			})
+
+			Context("with sort=start_date and order=desc", func() {
+				It("should pass Sort and Order to the repository filter", func() {
+					var capturedFilter repository.EventListFilter
+					mockRepo.listFunc = func(
+						ctx context.Context,
+						filter repository.EventListFilter,
+						offset, limit int,
+					) ([]*entity.Event, int64, error) {
+						capturedFilter = filter
+						return []*entity.Event{}, 0, nil
+					}
+
+					input := event.ListEventsInput{
+						Page:    1,
+						PerPage: 20,
+						Sort:    "start_date",
+						Order:   "desc",
+					}
+
+					_, err := usecase.List(ctx, input)
+
+					Expect(err).To(BeNil())
+					Expect(capturedFilter.Sort).To(Equal("start_date"))
+					Expect(capturedFilter.Order).To(Equal("desc"))
+				})
+			})
+
+			Context("with empty Sort and Order (default behavior)", func() {
+				It("should pass empty Sort and Order to the repository filter", func() {
+					var capturedFilter repository.EventListFilter
+					mockRepo.listFunc = func(
+						ctx context.Context,
+						filter repository.EventListFilter,
+						offset, limit int,
+					) ([]*entity.Event, int64, error) {
+						capturedFilter = filter
+						return []*entity.Event{}, 0, nil
+					}
+
+					input := event.ListEventsInput{
+						Page:    1,
+						PerPage: 20,
+					}
+
+					_, err := usecase.List(ctx, input)
+
+					Expect(err).To(BeNil())
+					Expect(capturedFilter.Sort).To(Equal(""))
+					Expect(capturedFilter.Order).To(Equal(""))
+				})
+			})
+
+			Context("with OrganizerID filter combined with Sort and Order", func() {
+				It("should pass all filter fields including Sort and Order to the repository", func() {
+					var capturedFilter repository.EventListFilter
+					mockRepo.listFunc = func(
+						ctx context.Context,
+						filter repository.EventListFilter,
+						offset, limit int,
+					) ([]*entity.Event, int64, error) {
+						capturedFilter = filter
+						return []*entity.Event{}, 0, nil
+					}
+
+					input := event.ListEventsInput{
+						OrganizerID: &userID,
+						Page:        1,
+						PerPage:     20,
+						Sort:        "name",
+						Order:       "asc",
+					}
+
+					_, err := usecase.List(ctx, input)
+
+					Expect(err).To(BeNil())
+					Expect(capturedFilter.OrganizerID).NotTo(BeNil())
+					Expect(*capturedFilter.OrganizerID).To(Equal(userID))
+					Expect(capturedFilter.Sort).To(Equal("name"))
+					Expect(capturedFilter.Order).To(Equal("asc"))
+				})
+			})
+		})
 	})
 
 	Describe("GetStats", func() {


### PR DESCRIPTION
## Summary
Fixes [#49](https://github.com/fumkob/ezqrin-server/issues/49). The `sort` and `order` query parameters on `GET /events` were silently ignored — the handler parsed them into `ListEventsInput`, but the usecase did not propagate them to `EventListFilter`, and the repository hardcoded `ORDER BY e.created_at DESC`. This PR wires the parameters through all three layers and applies them in the SQL query.

## Changes
- **Domain**: Added `Sort` and `Order` fields to `EventListFilter` (`internal/domain/repository/event_repository.go`).
- **Infrastructure**: Introduced an `allowedEventSortColumns` whitelist (`created_at`, `updated_at`, `name`, `start_date`, `end_date`, `status`) and a `buildOrderByClause` helper that builds the `ORDER BY` clause safely. Unknown sort values fall back to `e.created_at`; unknown order values fall back to `DESC`. A secondary sort on `e.id ASC` is appended for stable pagination.
- **Usecase**: Pass `input.Sort` / `input.Order` from `ListEventsInput` into `EventListFilter`.
- **CHANGELOG**: Added v0.2.2 entry covering this fix and the earlier release-workflow backtick fix (#79).

## Behavior
- `?sort=name&order=asc` now returns events sorted by name ascending (previously: `created_at DESC`).
- Empty `sort`/`order` preserves the prior `created_at DESC` behavior — no breaking change.
- Invalid `sort` values (including SQL injection attempts like `; DROP TABLE events; --`) fall back to the default column without error or data damage.

## Testing
- [x] Repository integration tests (5): default, name ASC/DESC, start_date ASC, invalid/injection fallback.
- [x] Usecase unit tests (4): verify `Sort`/`Order` propagate into `EventListFilter` (gomock).
- [x] Handler unit test (1): verify query params propagate into `ListEventsInput`.
- [x] `make lint` clean (golangci-lint).
- [x] `make test` passes — 115 of 115 specs.
- [x] Code review (`@code-reviewer`) — no Critical/High findings; Medium suggestions applied.

## Checklist
- [x] OpenAPI contract unchanged (no spec edits required — params already documented).
- [x] No mock regeneration needed — `EventRepository` interface signature is unchanged.
- [x] CHANGELOG entry added for v0.2.2.
- [ ] Tag `v0.2.2` and push after merge to trigger GitHub Release.